### PR TITLE
Fix: Object.getOwnPropertyDescriptor and Object.getOwnPropertyNames

### DIFF
--- a/Object/getOwnPropertyDescriptor.js
+++ b/Object/getOwnPropertyDescriptor.js
@@ -1,27 +1,25 @@
 if (!Object.getOwnPropertyDescriptor) {
 
-	Object.getOwnPropertyDescriptor = function getOwnPropertyDescriptor(object, property) {
-	if (Object(object) !== object) 
-		{
-			throw new TypeError('Object.getOwnPropertyDescriptor can only be called on Objects.');
-		}
+    Object.getOwnPropertyDescriptor = function getOwnPropertyDescriptor(object, property) {
+        if (Object(object) !== object) {
+            throw new TypeError('Object.getOwnPropertyDescriptor can only be called on Objects.');
+        }
 
-	var descriptor;
-	if(!Object.prototype.hasOwnProperty.call(object, property))
-		{
-			return descriptor;
-		}
+        var descriptor;
+        if (!Object.prototype.hasOwnProperty.call(object, property)) {
+            return descriptor;
+        }
 
-    descriptor = {
-        enumerable: Object.prototype.propertyIsEnumerable.call(object, property),
-        configurable: true
-    };
+        descriptor = {
+            enumerable: Object.prototype.propertyIsEnumerable.call(object, property),
+            configurable: true
+        };
 
-    descriptor.value = object[property];
+        descriptor.value = object[property];
 
-    var psPropertyType = object.reflect.find(property).type;
-	descriptor.writable = (psPropertyType === "readwrite");
+        var psPropertyType = object.reflect.find(property).type;
+        descriptor.writable = !(psPropertyType === "readonly");
 
-    return descriptor;
-	}
+        return descriptor;
+    }
 }

--- a/Object/getOwnPropertyNames.js
+++ b/Object/getOwnPropertyNames.js
@@ -4,13 +4,22 @@ if (!Object.getOwnPropertyNames) {
         if (Object(object) !== object) {
             throw new TypeError('Object.getOwnPropertyNames can only be called on Objects.');
         }
-
-        var props = object.reflect.properties;
-        var methods = object.reflect.methods;
-        var all = methods.concat(props);
         var names = [];
+        var hasOwnProperty = Object.prototype.hasOwnProperty;
+        var propertyIsEnumerable = Object.prototype.propertyIsEnumerable;
+        for (var prop in object) {
+            if (hasOwnProperty.call(object, prop)) {
+                names.push(prop);
+            }
+        }
+        var properties = object.reflect.properties;
+        var methods = object.reflect.methods;
+        var all = methods.concat(properties);
         for (var i = 0; i < all.length; i++) {
-            names.push(all[i].name);
+            var prop = all[i].name;
+            if (hasOwnProperty.call(object, prop) && !(propertyIsEnumerable.call(object, prop))) {
+                names.push(prop);
+            }
         }
         return names;
     };

--- a/Object/keys.js
+++ b/Object/keys.js
@@ -1,29 +1,15 @@
-/*
-Original taken from
-https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Polyfill
-
-Ther is no EnumBug in Photoshop scripting environment, so i cut unused code.
-*/
-
 if (!Object.keys) {
-  Object.keys = (function() {
-    var hasOwnProperty = Object.prototype.hasOwnProperty;
-
-    return function(obj) {
-      if (Object(obj) !== obj) {
-        throw new TypeError('Object.keys can only be called on Objects.');
-      }
-
-      var result = [],
-        prop, i;
-
-      for (prop in obj) {
-        if (hasOwnProperty.call(obj, prop)) {
-          result.push(prop);
+    Object.keys = function(object) {
+        if (Object(object) !== object) {
+            throw new TypeError('Object.keys can only be called on Objects.');
         }
-      }
-
-      return result;
+        var hasOwnProperty = Object.prototype.hasOwnProperty;
+        var result = [];
+        for (var prop in object) {
+            if (hasOwnProperty.call(object, prop)) {
+                result.push(prop);
+            }
+        }
+        return result;
     };
-  }());
 }


### PR DESCRIPTION
Object.getOwnPropertyDescriptor:  minor fix,  old version returns
descriptor for method properties, wich contains writable property wich
was always false. Now this property is always true for methods.
Object.getOwnPropertyNames: fix, now it returns only OWN properties.
Object.keys: refactor