### PR TITLE
Add missing `.value` reference to `Object.create()`

### DIFF
--- a/Object/create.js
+++ b/Object/create.js
@@ -39,7 +39,7 @@ if (!Object.create) {
               throw new TypeError('getters & setters can not be defined on this javascript engine');
             }
             if ('value' in descriptor) {
-              obj[prop] = Properties[prop];
+              obj[prop] = Properties[prop].value;
             }
 
           }


### PR DESCRIPTION
Fix for https://github.com/ExtendScript/extendscript-es5-shim/issues/26